### PR TITLE
fix: prioritize manifest over default registry in config

### DIFF
--- a/src/bin/cargo/commands/info.rs
+++ b/src/bin/cargo/commands/info.rs
@@ -29,7 +29,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
     let spec = PackageIdSpec::parse(package)
         .with_context(|| format!("invalid package ID specification: `{package}`"))?;
 
-    let reg_or_index = args.registry_or_index(gctx)?;
+    let reg_or_index = args.registry_or_index_with_default(gctx)?;
     info(&spec, gctx, reg_or_index)?;
     Ok(())
 }

--- a/src/bin/cargo/commands/install.rs
+++ b/src/bin/cargo/commands/install.rs
@@ -167,7 +167,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
     } else if krates.is_empty() {
         from_cwd = true;
         SourceId::for_path(gctx.cwd())?
-    } else if let Some(reg_or_index) = args.registry_or_index(gctx)? {
+    } else if let Some(reg_or_index) = args.registry_or_index_with_default(gctx)? {
         match reg_or_index {
             ops::RegistryOrIndex::Registry(r) => SourceId::alt_registry(gctx, &r)?,
             ops::RegistryOrIndex::Index(url) => SourceId::for_registry(&url)?,

--- a/src/bin/cargo/commands/login.rs
+++ b/src/bin/cargo/commands/login.rs
@@ -21,7 +21,7 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
-    let reg = args.registry_or_index(gctx)?;
+    let reg = args.registry_or_index_with_default(gctx)?;
     assert!(
         !matches!(reg, Some(RegistryOrIndex::Index(..))),
         "must not be index URL"

--- a/src/bin/cargo/commands/logout.rs
+++ b/src/bin/cargo/commands/logout.rs
@@ -14,7 +14,7 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
-    let reg = args.registry_or_index(gctx)?;
+    let reg = args.registry_or_index_with_default(gctx)?;
     assert!(
         !matches!(reg, Some(RegistryOrIndex::Index(..))),
         "must not be index URL"

--- a/src/bin/cargo/commands/owner.rs
+++ b/src/bin/cargo/commands/owner.rs
@@ -37,7 +37,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
     let opts = OwnersOptions {
         krate: args.get_one::<String>("crate").cloned(),
         token: args.get_one::<String>("token").cloned().map(Secret::from),
-        reg_or_index: args.registry_or_index(gctx)?,
+        reg_or_index: args.registry_or_index_with_default(gctx)?,
         to_add: args
             .get_many::<String>("add")
             .map(|xs| xs.cloned().collect()),

--- a/src/bin/cargo/commands/package.rs
+++ b/src/bin/cargo/commands/package.rs
@@ -60,7 +60,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
             gctx.cli_unstable().package_workspace,
         )?;
     }
-    let reg_or_index = args.registry_or_index(gctx)?;
+    let reg_or_index = args.registry_or_index()?;
     let ws = args.workspace(gctx)?;
     if ws.root_maybe().is_embedded() {
         return Err(anyhow::format_err!(

--- a/src/bin/cargo/commands/publish.rs
+++ b/src/bin/cargo/commands/publish.rs
@@ -35,7 +35,7 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
-    let reg_or_index = args.registry_or_index(gctx)?;
+    let reg_or_index = args.registry_or_index()?;
     let ws = args.workspace(gctx)?;
     if ws.root_maybe().is_embedded() {
         return Err(anyhow::format_err!(

--- a/src/bin/cargo/commands/search.rs
+++ b/src/bin/cargo/commands/search.rs
@@ -24,7 +24,7 @@ pub fn cli() -> Command {
 }
 
 pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
-    let reg_or_index = args.registry_or_index(gctx)?;
+    let reg_or_index = args.registry_or_index_with_default(gctx)?;
     let limit = args.value_of_u32("limit")?;
     let limit = min(100, limit.unwrap_or(10));
     let query: Vec<&str> = args

--- a/src/bin/cargo/commands/yank.rs
+++ b/src/bin/cargo/commands/yank.rs
@@ -39,7 +39,7 @@ pub fn exec(gctx: &mut GlobalContext, args: &ArgMatches) -> CliResult {
         krate.map(|s| s.to_string()),
         version.map(|s| s.to_string()),
         args.get_one::<String>("token").cloned().map(Secret::from),
-        args.registry_or_index(gctx)?,
+        args.registry_or_index_with_default(gctx)?,
         args.flag("undo"),
     )?;
     Ok(())

--- a/src/cargo/ops/cargo_package.rs
+++ b/src/cargo/ops/cargo_package.rs
@@ -284,7 +284,13 @@ fn get_registry(
 ) -> CargoResult<SourceId> {
     let reg_or_index = match reg_or_index.clone() {
         Some(r) => Some(r),
-        None => infer_registry(pkgs)?,
+        None => {
+            let reg = infer_registry(pkgs)?;
+            match reg {
+                Some(r) => Some(r),
+                None => gctx.default_registry()?.map(RegistryOrIndex::Registry)
+            }
+        }
     };
 
     // Validate the registry against the packages' allow-lists.

--- a/src/cargo/ops/registry/publish.rs
+++ b/src/cargo/ops/registry/publish.rs
@@ -101,6 +101,12 @@ pub fn publish(ws: &Workspace<'_>, opts: &PublishOpts<'_>) -> CargoResult<()> {
         }
         None => {
             let reg = super::infer_registry(&just_pkgs)?;
+
+            let reg = match reg {
+                Some(reg) => Some(reg),
+                None => opts.gctx.default_registry()?.map(RegistryOrIndex::Registry),
+            };
+
             validate_registry(&just_pkgs, reg.as_ref())?;
             if let Some(RegistryOrIndex::Registry(ref registry)) = &reg {
                 if registry != CRATES_IO_REGISTRY {

--- a/src/cargo/util/command_prelude.rs
+++ b/src/cargo/util/command_prelude.rs
@@ -881,11 +881,18 @@ Run `{cmd}` to see possible targets."
         )
     }
 
-    fn registry_or_index(&self, gctx: &GlobalContext) -> CargoResult<Option<RegistryOrIndex>> {
+    fn registry_or_index_with_default(&self, gctx: &GlobalContext) -> CargoResult<Option<RegistryOrIndex>> {
+        match self.registry_or_index()? {
+            Some(reg_or_index) => Ok(Some(reg_or_index)),
+            None => Ok(gctx.default_registry()?.map(RegistryOrIndex::Registry))
+        }
+    }
+
+    fn registry_or_index(&self) -> CargoResult<Option<RegistryOrIndex>> {
         let registry = self._value_of("registry");
         let index = self._value_of("index");
         let result = match (registry, index) {
-            (None, None) => gctx.default_registry()?.map(RegistryOrIndex::Registry),
+            (None, None) => None,
             (None, Some(i)) => Some(RegistryOrIndex::Index(i.into_url()?)),
             (Some(r), None) => {
                 RegistryName::new(r)?;


### PR DESCRIPTION
As of `cargo 1.83.0 (5ffbef321 2024-10-29)` the Cargo book https://doc.rust-lang.org/cargo/commands/cargo-publish.html#options mentions the registry selection would be in the order of CLI arg ->  package.publish Cargo.toml if a single key -> registry.default config key.

However, the code actually checks the config key prior to Cargo.toml. This causes issue when a default registry is specified in config, but another different registry is specified in the manifest file.